### PR TITLE
Update index existing ebooks link

### DIFF
--- a/_sources/index.rst
+++ b/_sources/index.rst
@@ -7,7 +7,7 @@ The Runestone platform allows you to create, modify, use, and serve interactive 
 
 With Runestone you can:
 
-* Use any of the existing ebooks that are listed at the following link `here <http://runestoneinteractive.org/library.html>`_.
+* Use any of the existing ebooks that are listed at the following link `here <https://runestone.academy/runestone/books/index>`_.
 * Create a private course for your students as shown in the following Video and Chapter 4 of this guide.  Your course will have to have a unique name and your students can register for the course using the unique name.
 
 Quick Start


### PR DESCRIPTION
This fixes issue #1038 which is present on RunestoneServer at https://github.com/RunestoneInteractive/RunestoneComponents/issues/1038 

The link is updated from the dead 404 link to https://runestone.academy/runestone/books/index 